### PR TITLE
removes non-existent rover_status placeholder from list

### DIFF
--- a/src/miscellaneous/placeholders.md
+++ b/src/miscellaneous/placeholders.md
@@ -49,7 +49,6 @@ These placeholders are available if the user has linked their Roblox account via
 
 |Placeholder|Description |
 |--|--|
-| %rover_status% | status |
 | %rover_username% | The user's Roblox username |
 | %rover_id% | The user's numeric Roblox ID |
 | %rover_displayname% | The user's Roblox display name |


### PR DESCRIPTION
<img width="792" alt="Screenshot 2025-03-22 at 3 48 59 PM" src="https://github.com/user-attachments/assets/1ef68eea-48b9-4675-af94-ef98806bb20b" />
⬆️This `rover_status` doesn't actually exist in codebase.⬇️

<img width="501" alt="Screenshot 2025-03-22 at 3 50 11 PM" src="https://github.com/user-attachments/assets/b18a0522-1f44-406b-8629-334a9f3f413b" />
