### PR TITLE
Deprecate Bloxlink placeholders (API disabled)

### DIFF
--- a/src/integrations/building-integrations.md
+++ b/src/integrations/building-integrations.md
@@ -9,8 +9,6 @@ If you run a service that incorporates [Discord OAuth](https://discord.com/devel
 
 A simple example would be a forum! When a user opens a ticket in your Discord server, you could include the user's forum username automatically.
 
-Another example is our built-in Bloxlink integration, which allows you to include the Roblox usernames, profile URLs and more in tickets. The Bloxlink integration is automatically enabled in all servers. You can view the welcome message placeholders available through it [here](https://docs.tickets.bot/setup/placeholders#bloxlink).
-
 Integrations do not necessarily need to fetch information about a user either! In the [next tutorial](), we show you how we built the cryptocurrency price integration.
 
 ## Background Setup

--- a/src/miscellaneous/placeholders.md
+++ b/src/miscellaneous/placeholders.md
@@ -49,16 +49,7 @@ Placeholders marked with a * are premium features. Learn more about premium [her
 All integration placeholders are automatically active, you do not have to do anything special apart from include them in your welcome message.
 
 #### Bloxlink
-These placeholders are available if the user has linked their Roblox account via [Bloxlink](https://blox.link)
-
-|Placeholder|Description |
-|--|--|
-| %roblox_username% | The user's Roblox username |
-| %roblox_id% | The user's numeric Roblox ID |
-| %roblox_display_name% | The user's Roblox display name |
-| %roblox_profile_url% | The full clickable URL to the user's Roblox profile |
-| %roblox_account_age% | How long ago the user's Roblox account was created |
-| %roblox_account_created% | The date on which the user's Roblox account was created |
+> ⚠️ **Bloxlink placeholders are currently unavailable.** Bloxlink has disabled their Global API, which these placeholders relied upon. We are investigating alternative solutions to restore Roblox placeholder support, but are unable to provide an estimated timeline.
 
 ## Custom Naming Scheme Placeholders:
 |Placeholder|Description|


### PR DESCRIPTION
Remove the Bloxlink placeholder table and example reference, replacing them with a warning that Bloxlink's Global API is disabled. Updated src/miscellaneous/placeholders.md to show a notice about unavailability and removed the Bloxlink example line from src/integrations/building-integrations.md. Reason: Bloxlink disabled the Global API; alternatives are being investigated.

<img width="1002" height="245" alt="image" src="https://github.com/user-attachments/assets/c60e0742-e54a-4ada-87c6-d27e5e5d5b96" />
